### PR TITLE
Remove flake8 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Click
 requests
 beautifulsoup4
 flask
-flake8
 pylint
 pylint-quotes
 click-man


### PR DESCRIPTION
This PR removes flake8 from requirements.txt since we are switching to pylint.